### PR TITLE
docs(assets): add brand assets license (v1)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+TrustChainX Brand Assets License
+Copyright (c) 2025 TrustChainX. All rights reserved.
+
+This repository contains TrustChainX brand and application assets (the “Brand Assets”), including but not limited to logos, icons, wordmarks, social preview images, and related files.
+
+PERMITTED USES
+- Press, media, analysts, partners, and integrators may use the Brand Assets to factually refer to TrustChainX.
+- You may link to this repository and to official releases, and you may redistribute the original, unmodified files for reference.
+- Limited resizing is allowed if aspect ratio and clear-space are preserved.
+
+PROHIBITED USES
+- Do NOT modify colors, shapes, proportions, effects, or spacing, and do NOT create derivative marks.
+- Do NOT combine the Brand Assets with other logos or marks, or place them in confusing or misleading contexts.
+- Do NOT use the Brand Assets in app icons, products, websites, or domains that are not officially affiliated with TrustChainX.
+- Do NOT imply endorsement, sponsorship, or partnership without prior written permission from TrustChainX.
+
+TRADEMARKS & OWNERSHIP
+- TrustChainX names and logos are trademarks of TrustChainX. No trademark rights are granted by this license.
+- TrustChainX retains all rights, title, and interest in and to the Brand Assets.
+
+TERMINATION
+- Permission is revocable at any time. TrustChainX may require you to cease use of the Brand Assets for any reason.
+
+CONTACT
+- For permissions, partnerships, or media inquiries: ceo@trustchainx.io


### PR DESCRIPTION
- Add TrustChainX Brand Assets License (restrictive use, no modifications, no endorsement).
- Applies to logos/icons/manifests in this repo.